### PR TITLE
feat(sqldef) implement mysqldef toolregistry

### DIFF
--- a/plugins/sqldef/go.mod
+++ b/plugins/sqldef/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/coreos/go-oidc/v3 v3.11.0 // indirect
 	github.com/creasty/defaults v1.6.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -30,6 +31,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/pipe-cd/pipecd v0.52.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
@@ -58,5 +60,6 @@ require (
 	google.golang.org/grpc v1.64.1 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/plugins/sqldef/toolregistry/registry.go
+++ b/plugins/sqldef/toolregistry/registry.go
@@ -1,0 +1,47 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package toolregistry installs and manages the needed tools
+// such as kubectl, helm... for executing tasks in pipeline.
+package toolregistry
+
+import (
+	"cmp"
+	"context"
+)
+
+const (
+	defaultSqldefVersion = "2.0.4"
+)
+
+type client interface {
+	InstallTool(ctx context.Context, name, version, script string) (string, error)
+}
+
+func NewRegistry(client client) *Registry {
+	return &Registry{
+		client: client,
+	}
+}
+
+// Registry provides functions to get path to the needed tools.
+type Registry struct {
+	client client
+}
+
+// Mysqldef installs the mysqldef tool with the given version and return the path to the installed binary.
+// If the version is empty, the default version will be used.
+func (r *Registry) Mysqldef(ctx context.Context, version string) (string, error) {
+	return r.client.InstallTool(ctx, "mysqldef", cmp.Or(version, defaultSqldefVersion), MysqldefInstallScript)
+}

--- a/plugins/sqldef/toolregistry/registry_test.go
+++ b/plugins/sqldef/toolregistry/registry_test.go
@@ -1,0 +1,39 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolregistry
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/pipe-cd/piped-plugin-sdk-go/toolregistry/toolregistrytest"
+)
+
+func TestRegistry_Sqldef(t *testing.T) {
+	t.Parallel()
+
+	c := toolregistrytest.NewTestToolRegistry(t)
+
+	r := NewRegistry(c)
+
+	path, err := r.Mysqldef(context.Background(), "2.0.4")
+
+	assert.NoError(t, err)
+	require.NotEmpty(t, path)
+
+	assert.Contains(t, path, "mysqldef-2.0.4", "Expected file title not found in path")
+}

--- a/plugins/sqldef/toolregistry/script.go
+++ b/plugins/sqldef/toolregistry/script.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The PipeCD Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package toolregistry
+
+const MysqldefInstallScript = `
+cd {{ .TmpDir }}
+pwd
+curl -LO https://github.com/sqldef/sqldef/releases/download/v{{ .Version }}/mysqldef_{{ .Os }}_{{ .Arch }}.zip
+
+echo https://github.com/sqldef/sqldef/releases/download/v{{ .Version }}/mysqldef_{{ .Os }}_{{ .Arch }}.zip 
+
+unzip mysqldef_{{ .Os }}_{{ .Arch }}.zip
+chmod +x mysqldef
+cp mysqldef {{ .OutPath }}
+`


### PR DESCRIPTION
### What this PR does

We are implementing toolregistry support for mysqldef, and will add support for other databases (PostgreSQL, MSSQL, SQLite) once MySQL path works end-to-end.

### Which issue(s) this PR fixes

part of https://github.com/pipe-cd/pipecd/issues/5808

