### PR TITLE
[OpenTofu Plugin] fix Rollback: change tds to rds

### DIFF
--- a/plugins/opentofu/deployment/rollback.go
+++ b/plugins/opentofu/deployment/rollback.go
@@ -31,7 +31,7 @@ func (p *Plugin) executeRollbackStage(ctx context.Context, input *sdk.ExecuteSta
 		return sdk.StageStatusFailure
 	}
 
-	cmd, err := initOpenTofuCommand(ctx, input.Client, input.Request.TargetDeploymentSource, dts[0])
+	cmd, err := initOpenTofuCommand(ctx, input.Client, rds, dts[0])
 	if err != nil {
 		return sdk.StageStatusFailure
 	}


### PR DESCRIPTION
### What this PR does
change `TargetDeploymentSource` to `RunningDeploymentSource` for the rollback

### Why we need it / Without this PR, what is the problem?

