### PR TITLE
Disable go cache in plugin release workflow

### DIFF
--- a/.github/workflows/release-plugin.yaml
+++ b/.github/workflows/release-plugin.yaml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
       - name: Determine Plugin Info
         run: echo "PLUGIN_NAME=$(basename ${{ inputs.path }})" >> $GITHUB_ENV
       - name: Build binary artifacts


### PR DESCRIPTION
### What this PR does

ssia

### Why we need it / Without this PR, what is the problem?

Fix error on setting go cache (ref: https://github.com/pipe-cd/community-plugins/actions/runs/17667024392/job/50210463222#step:3:12).
Since this is a multi-module repository and the workflow is designed to build individual plugins, the simplest fix is to disable caching.

### Which issue(s) this PR fixes

Follow PR #43 

<!-- Use 'Part of' instead if this PR does NOT fix the issue completely. -->
<!-- Part of # -->

